### PR TITLE
fix: keep one replica until queue is empty

### DIFF
--- a/rq_autoscaler/__init__.py
+++ b/rq_autoscaler/__init__.py
@@ -1,6 +1,8 @@
 """RQ Autoscaler main module."""
 from __future__ import annotations
 
+from math import ceil
+
 from kr8s.objects import Deployment
 from loguru import logger
 from pydantic import RedisDsn
@@ -44,7 +46,7 @@ class Autoscaler:
     def determine_replica_count(self) -> int:
         """Return the ideal number of replicas."""
         queue_length = self.get_queue_length()
-        replicas = queue_length // self.tasks_per_replica
+        replicas = ceil(queue_length / self.tasks_per_replica)
         if replicas < self.min_replicas:
             replicas = self.min_replicas
         elif replicas > self.max_replicas:


### PR DESCRIPTION
this change ensures that the calculation only returns 0 once there are no jobs remaining, rather than rounding down when there are very few jobs left.

example:

```python
In [1]: from math import ceil
In [2]: for jobs in range(10, -1, -1):
   ...:     workers = ceil(jobs / 3)
   ...:     print(f"jobs: {jobs}, workers: {workers}")
   ...:
jobs: 10, workers: 4
jobs: 9, workers: 3
jobs: 8, workers: 3
jobs: 7, workers: 3
jobs: 6, workers: 2
jobs: 5, workers: 2
jobs: 4, workers: 2
jobs: 3, workers: 1
jobs: 2, workers: 1
jobs: 1, workers: 1
jobs: 0, workers: 0
```